### PR TITLE
change filetype back to csv (for api) and fix typo in safe to swim

### DIFF
--- a/CEDEN_DataRefresh.py
+++ b/CEDEN_DataRefresh.py
@@ -821,7 +821,7 @@ if __name__ == "__main__":
 		print("\nStarting data subset for Safe to Swim...")
 		WaterChem = FILES['WaterChemistryData']
 		path, fileName = os.path.split(WaterChem)
-		analytes = ['E. Coli', 'Enterococcus', 'Coliform, Total', 'Coliform, Fecal', ]
+		analytes = ['E. coli', 'Enterococcus', 'Coliform, Total', 'Coliform, Fecal', ]
 		newFileName = 'SafeToSwim' + extension
 		column_filter = 'Analyte'
 		name, location, sitesname, siteslocation = selectByAnalyte(path=path, fileName=fileName, newFileName=newFileName, analytes=analytes,

--- a/FHAB_BloomReport.py
+++ b/FHAB_BloomReport.py
@@ -75,9 +75,9 @@ if __name__ == "__main__":
 	FHAB = 'FHAB_BloomReport'
 	###   Ideally data.ca.gov will be able to generate data preview for tab delimited txt files... until then
 	### extension type. Data.ca.gov requires csv for preview functionality
-	ext = '.tsv'
+	ext = '.csv'
 	### delimiter type.
-	sep = '\t'
+	sep = ','
 	file = os.path.join(path, FHAB + ext)
 	cnxn = pyodbc.connect(Driver='ODBC Driver 11 for SQL Server', Server=SERVER, uid=UID, Trusted_Connection='Yes')
 	cursor = cnxn.cursor()


### PR DESCRIPTION
Changed the file type for the FHAB Bloom Report data set back to CSV so that we can use the DKAN API. Also fixed a typo in the analytes list for the Safe to Swim data set. 